### PR TITLE
PR for AWS Java SDK version updates in pom.xml

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,2 @@
+# JavaAPI
+Just some stuff.

--- a/aws-request-signing-apache-interceptor/pom.xml
+++ b/aws-request-signing-apache-interceptor/pom.xml
@@ -30,7 +30,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.12</version>
+      <version>4.13.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/aws-request-signing-apache-interceptor/pom.xml
+++ b/aws-request-signing-apache-interceptor/pom.xml
@@ -23,7 +23,7 @@
   <properties>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
-    <aws-java-sdk.version>1.12.126</aws-java-sdk.version>
+    <aws-java-sdk.version>1.12.152</aws-java-sdk.version>
   </properties>
 
   <dependencies>

--- a/aws-request-signing-apache-interceptor/pom.xml
+++ b/aws-request-signing-apache-interceptor/pom.xml
@@ -23,7 +23,7 @@
   <properties>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
-    <aws-java-sdk.version>1.12.205</aws-java-sdk.version>
+    <aws-java-sdk.version>1.12.206</aws-java-sdk.version>
   </properties>
 
   <dependencies>

--- a/aws-request-signing-apache-interceptor/pom.xml
+++ b/aws-request-signing-apache-interceptor/pom.xml
@@ -23,7 +23,7 @@
   <properties>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
-    <aws-java-sdk.version>1.12.126</aws-java-sdk.version>
+    <aws-java-sdk.version>1.12.127</aws-java-sdk.version>
   </properties>
 
   <dependencies>

--- a/aws-request-signing-apache-interceptor/pom.xml
+++ b/aws-request-signing-apache-interceptor/pom.xml
@@ -23,7 +23,7 @@
   <properties>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
-    <aws-java-sdk.version>1.11.221</aws-java-sdk.version>
+    <aws-java-sdk.version>1.12.126</aws-java-sdk.version>
   </properties>
 
   <dependencies>

--- a/aws-request-signing-apache-interceptor/pom.xml
+++ b/aws-request-signing-apache-interceptor/pom.xml
@@ -23,7 +23,7 @@
   <properties>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
-    <aws-java-sdk.version>1.12.206</aws-java-sdk.version>
+    <aws-java-sdk.version>1.12.461</aws-java-sdk.version>
   </properties>
 
   <dependencies>

--- a/aws-request-signing-apache-interceptor/pom.xml
+++ b/aws-request-signing-apache-interceptor/pom.xml
@@ -23,7 +23,7 @@
   <properties>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
-    <aws-java-sdk.version>1.11.221</aws-java-sdk.version>
+    <aws-java-sdk.version>1.12.107</aws-java-sdk.version>
   </properties>
 
   <dependencies>

--- a/aws-request-signing-apache-interceptor/pom.xml
+++ b/aws-request-signing-apache-interceptor/pom.xml
@@ -23,7 +23,7 @@
   <properties>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
-    <aws-java-sdk.version>1.11.221</aws-java-sdk.version>
+    <aws-java-sdk.version>1.12.122</aws-java-sdk.version>
   </properties>
 
   <dependencies>

--- a/aws-request-signing-apache-interceptor/pom.xml
+++ b/aws-request-signing-apache-interceptor/pom.xml
@@ -23,7 +23,7 @@
   <properties>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
-    <aws-java-sdk.version>1.12.126</aws-java-sdk.version>
+    <aws-java-sdk.version>1.12.205</aws-java-sdk.version>
   </properties>
 
   <dependencies>

--- a/aws-request-signing-apache-interceptor/pom.xml
+++ b/aws-request-signing-apache-interceptor/pom.xml
@@ -23,7 +23,7 @@
   <properties>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
-    <aws-java-sdk.version>1.12.126</aws-java-sdk.version>
+    <aws-java-sdk.version>1.12.132</aws-java-sdk.version>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
These are simple updates to the AWS Java SDK version 1.11.221 -> 1.12.126 in pom.xml as proposed by Snyk security scans